### PR TITLE
Allow access to font metrics info

### DIFF
--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -68,6 +68,9 @@ module.exports =
 
     return height
 
+  currentFontMetrics: () ->
+    {ascender: (@_font.ascender/ 1000 * @_fontSize), descender: (@_font.descender/ 1000 * @_fontSize), gap: @_lineGap, lineHeight: @currentLineHeight(true)}
+
   list: (list, x, y, options, wrapper) ->
     options = @_initOptions(x, y, options)
 


### PR DESCRIPTION
In order to have multiple types in a line, and have all the baselines match up, you need more than just the line height.

Should I also include the js build files in the pull request?